### PR TITLE
fix sonarscan deprecation warnings

### DIFF
--- a/src/org/zowe/jenkins_shared_library/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/jenkins_shared_library/pipelines/generic/GenericPipeline.groovy
@@ -1237,13 +1237,13 @@ class GenericPipeline extends Pipeline {
                             def extraEnvironments = ""
                             if (arguments.javaHome) {
                                 // warning The version of Java (1.8.0_242) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.
-                                extraEnvironments = "JAVA_HOME=${arguments.javaHome} && PATH=\${JAVA_HOME}/bin:\$PATH && "
+                                extraEnvironments = "JAVA_HOME=${arguments.javaHome}\nPATH=\${JAVA_HOME}/bin:\$PATH\n"
                             }
                             if (arguments.nodeJsVersion && arguments.nvmInitScript) {
                                 // The version of node.js (8) you have used to run this analysis is deprecated and we stopped accepting it. Please update to at least node.js 10.
                                 // Temporarily you can set the property 'sonar.scanner.force-deprecated-node-version-grace-period' to 'true' to continue using node.js 8
                                 // This will only work until Mon Feb 15 08:00:00 UTC 2021, afterwards all scans will fail.
-                                extraEnvironments += ". ${arguments.nvmInitScript} && nvm install ${arguments.nodeJsVersion} && nvm use ${arguments.nodeJsVersion} && "
+                                extraEnvironments += "set +x\n. ${arguments.nvmInitScript}\nnvm install ${arguments.nodeJsVersion}\nnvm use ${arguments.nodeJsVersion}\nset -x\n"
                             }
                             this.steps.sh "${extraEnvironments}${scannerHome}/bin/sonar-scanner"
 

--- a/src/org/zowe/jenkins_shared_library/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/jenkins_shared_library/pipelines/generic/GenericPipeline.groovy
@@ -1234,7 +1234,11 @@ class GenericPipeline extends Pipeline {
                     steps.timeout(time: 1, unit: 'HOURS') {
                         def scannerHome = this.steps.tool arguments.scannerTool
                         this.steps.withSonarQubeEnv(arguments.scannerServer) {
-                            this.steps.sh "${scannerHome}/bin/sonar-scanner"
+                            def scanCommand = "${scannerHome}/bin/sonar-scanner"
+                            if (arguments.javaHome) {
+                                scanCommand = "JAVA_HOME=${arguments.javaHome} && PATH=\${JAVA_HOME}/bin:\$PATH && ${scanCommand}"
+                            }
+                            this.steps.sh scanCommand
 
                             if (arguments.failBuild) {
                                 // fail build on quality gate failure

--- a/src/org/zowe/jenkins_shared_library/pipelines/generic/arguments/SonarScanStageArguments.groovy
+++ b/src/org/zowe/jenkins_shared_library/pipelines/generic/arguments/SonarScanStageArguments.groovy
@@ -54,7 +54,7 @@ class SonarScanStageArguments extends GenericStageArguments {
     String scannerServer
 
     /**
-     * Customize JAVA_HOME for sonar scan if the default JDK is not supported
+     * Customize JAVA_HOME for sonar scan if the default JDK is not supported.
      *
      * @Note This default value is where we put JDK v11 in zowe-jenkins-agent
      *       build image. Pipelines are not using this base image should
@@ -63,6 +63,20 @@ class SonarScanStageArguments extends GenericStageArguments {
      * @default {@code /usr/java/openjdk-11}
      */
     String javaHome = '/usr/java/openjdk-11'
+
+    /**
+     * Customize Node.JS version for sonar scan if the default version is not supported.
+     *
+     * @Note This requires nvm installed on the build image.
+     */
+    String nodeJsVersion = 'v10.23.2'
+
+    /**
+     * Path to nvm init script.
+     *
+     * @default {@code /home/jenkins/.nvm/nvm.sh}
+     */
+    String nvmInitScript = '/home/jenkins/.nvm/nvm.sh'
 
     /**
      * If the SonarQube server support branch scan.

--- a/src/org/zowe/jenkins_shared_library/pipelines/generic/arguments/SonarScanStageArguments.groovy
+++ b/src/org/zowe/jenkins_shared_library/pipelines/generic/arguments/SonarScanStageArguments.groovy
@@ -54,6 +54,17 @@ class SonarScanStageArguments extends GenericStageArguments {
     String scannerServer
 
     /**
+     * Customize JAVA_HOME for sonar scan if the default JDK is not supported
+     *
+     * @Note This default value is where we put JDK v11 in zowe-jenkins-agent
+     *       build image. Pipelines are not using this base image should
+     *       customize this value to match their environment.
+     *
+     * @default {@code /usr/java/openjdk-11}
+     */
+    String javaHome = '/usr/java/openjdk-11'
+
+    /**
      * If the SonarQube server support branch scan.
      *
      * @Note If enable branch scan on a SonarQube server which doesn't support,

--- a/src/org/zowe/jenkins_shared_library/pipelines/generic/arguments/SonarScanStageArguments.groovy
+++ b/src/org/zowe/jenkins_shared_library/pipelines/generic/arguments/SonarScanStageArguments.groovy
@@ -69,7 +69,7 @@ class SonarScanStageArguments extends GenericStageArguments {
      *
      * @Note This requires nvm installed on the build image.
      */
-    String nodeJsVersion = 'v10.23.2'
+    String nodeJsVersion = 'v10.18.1'
 
     /**
      * Path to nvm init script.


### PR DESCRIPTION
SonarScan is deprecating JDK v8 and Node.js v8.

```
warning The version of Java (1.8.0_242) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.

The version of node.js (8) you have used to run this analysis is deprecated and we stopped accepting it. Please update to at least node.js 10.
Temporarily you can set the property 'sonar.scanner.force-deprecated-node-version-grace-period' to 'true' to continue using node.js 8
This will only work until Mon Feb 15 08:00:00 UTC 2021, afterwards all scans will fail.
```

This is part of https://github.com/zowe/zowe-install-packaging/issues/1401.
